### PR TITLE
Fix date eras

### DIFF
--- a/archaeologie.bbx
+++ b/archaeologie.bbx
@@ -1439,4 +1439,10 @@
 }
 \docsvlist{shortjournal,shortseries}
 
+% this will not be needed in future versions of biblatex, see
+% https://github.com/plk/biblatex/commit/9a1f550222e294af5490488093a5e33e10493c63
+\providecommand*{\ifdateyearsequal}[2]{%
+  \ifboolexpr{ test {\iffieldsequal{#1year}{#2year}}
+               and test {\iffieldsequal{#1dateera}{#2dateera}}}}
+
 \endinput

--- a/english-archaeologie.lbx
+++ b/english-archaeologie.lbx
@@ -48,17 +48,17 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {}
-      {\datecircaprint
-       \printtext[#2date]{%
+      {\printtext[#2date]{%
+         \datecircaprint
          \iffieldundef{#2season}
-           {\iffieldsequal{#2year}{#2endyear}
+           {\ifdateyearsequal{#2}{#2end}
              {\csuse{mkbibdate#1}{}{#2month}{#2day}}
              {\csuse{mkbibdate#1}{#2year}{#2month}{#2day}%
-              \dateeraprint{#2}}}
-           {\iffieldsequal{#2year}{#2endyear}
+              \dateeraprint{#2year}}}
+           {\ifdateyearsequal{#2}{#2end}
              {\csuse{mkbibseasondate#1}{}{#2season}}
-             {\csuse{mkbibseasondate#1}{#2year}{#2season}}%
-              \dateeraprint{#2}}%
+             {\csuse{mkbibseasondate#1}{#2year}{#2season}%
+              \dateeraprint{#2year}}}%
          \dateuncertainprint
          \iffieldundef{#2endyear}
            {}
@@ -67,14 +67,14 @@
              {\bibdaterangesepx{#2}%
               \enddatecircaprint
               \iffieldundef{#2season}
-                {\iffieldsequal{#2year}{#2endyear}
+                {\ifdateyearsequal{#2}{#2end}
                   {\iffieldsequal{#2month}{#2endmonth}
                     {\csuse{mkbibdate#1}{#2endyear}{}{#2endday}}
                     {\csuse{mkbibdate#1}{#2endyear}{#2endmonth}{#2endday}}}
                   {\csuse{mkbibdate#1}{#2endyear}{#2endmonth}{#2endday}}}
                 {\csuse{mkbibseasondate#1}{#2endyear}{#2endseason}}%
               \enddateuncertainprint
-              \dateeraprint{#2}}}}}%
+              \dateeraprint{#2endyear}}}}}%
   \endgroup}
 
 \protected\gdef\lbx@us@mkdaterangetrunc@short#1#2{%
@@ -82,17 +82,17 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {}
-      {\datecircaprint
-       \printtext[#2date]{%
+      {\printtext[#2date]{%
+         \datecircaprint
          \iffieldundef{#2season}
-           {\iffieldsequal{#2year}{#2endyear}
+           {\ifdateyearsequal{#2}{#2end}
              {\csuse{mkbibdate#1}{}{#2month}{#2day}}
-             {\csuse{mkbibdate#1}{#2year}{#2month}{#2day}
-              \dateeraprint{#2}}}
-           {\iffieldsequal{#2year}{#2endyear}
+             {\csuse{mkbibdate#1}{#2year}{#2month}{#2day}%
+              \dateeraprint{#2year}}}
+           {\ifdateyearsequal{#2}{#2end}
              {\csuse{mkbibseasondate#1}{}{#2season}}
-             {\csuse{mkbibseasondate#1}{#2year}{#2season}}%
-              \dateeraprint{#2}}%
+             {\csuse{mkbibseasondate#1}{#2year}{#2season}%
+              \dateeraprint{#2year}}}%
          \dateuncertainprint
          \iffieldundef{#2endyear}
            {}
@@ -104,7 +104,7 @@
                  {\csuse{mkbibdate#1}{#2endyear}{#2endmonth}{#2endday}}
                  {\csuse{mkbibseasondate#1}{#2endyear}{#2endseason}}%
                \enddateuncertainprint
-               \dateeraprint{#2}}}}}%
+               \dateeraprint{#2endyear}}}}}%
   \endgroup}
 
 \protected\gdef\lbx@us@mkdaterangetruncextra@long#1#2{%
@@ -112,16 +112,17 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {}
-      {\datecircaprint
-       \printtext[#2date]{%
+      {\printtext[#2date]{%
+         \datecircaprint
          \iffieldundef{#2season}
-           {\iffieldsequal{#2year}{#2endyear}
+           {\ifdateyearsequal{#2}{#2end}
              {\csuse{mkbibdate#1}{}{#2month}{#2day}}
-             {\csuse{mkbibdate#1}{#2year}{#2month}{#2day}}}
-           {\iffieldsequal{#2year}{#2endyear}
+             {\csuse{mkbibdate#1}{#2year}{#2month}{#2day}%
+              \dateeraprint{#2year}}}%
+           {\ifdateyearsequal{#2}{#2end}
              {\csuse{mkbibseasondate#1}{}{#2season}}
-             {\csuse{mkbibseasondate#1}{#2year}{#2season}}%
-              \dateeraprint{#2}}%
+             {\csuse{mkbibseasondate#1}{#2year}{#2season}%
+              \dateeraprint{#2year}}}%
          \dateuncertainprint
          \iffieldundef{#2endyear}
            {\printfield{extradate}}
@@ -131,7 +132,7 @@
               {\bibdaterangesepx{#2}%
                \enddatecircaprint
                \iffieldundef{#2season}
-                 {\iffieldsequal{#2year}{#2endyear}
+                 {\ifdateyearsequal{#2}{#2end}
                    {\iffieldsequal{#2month}{#2endmonth}
                       {\csuse{mkbibdate#1}{#2endyear}{}{#2endday}}
                       {\csuse{mkbibdate#1}{#2endyear}{#2endmonth}{#2endday}}}
@@ -139,7 +140,7 @@
                  {\csuse{mkbibseasondate#1}{#2endyear}{#2endseason}}%
                \printfield{extradate}%
                \enddateuncertainprint
-               \dateeraprint{#2}}}}}%
+               \dateeraprint{#2endyear}}}}}%
   \endgroup}
 
 \protected\gdef\lbx@us@mkdaterangetruncextra@short#1#2{%
@@ -147,16 +148,17 @@
     \blx@metadateinfo{#2}%
     \iffieldundef{#2year}
       {}
-      {\datecircaprint
-       \printtext[#2date]{%
+      {\printtext[#2date]{%
+         \datecircaprint
          \iffieldundef{#2season}
-           {\iffieldsequal{#2year}{#2endyear}
+           {\ifdateyearsequal{#2}{#2end}
              {\csuse{mkbibdate#1}{}{#2month}{#2day}}
-             {\csuse{mkbibdate#1}{#2year}{#2month}{#2day}}}
-           {\iffieldsequal{#2year}{#2endyear}
+             {\csuse{mkbibdate#1}{#2year}{#2month}{#2day}%
+              \dateeraprint{#2year}}}%
+           {\ifdateyearsequal{#2}{#2end}
              {\csuse{mkbibseasondate#1}{}{#2season}}
-             {\csuse{mkbibseasondate#1}{#2year}{#2season}}%
-              \dateeraprint{#2}}%
+             {\csuse{mkbibseasondate#1}{#2year}{#2season}%
+              \dateeraprint{#2year}}}%
          \dateuncertainprint
          \iffieldundef{#2endyear}
            {\printfield{extradate}}
@@ -170,7 +172,7 @@
               {\csuse{mkbibseasondate#1}{#2endyear}{#2endseason}}%
             \printfield{extradate}%
             \enddateuncertainprint
-            \dateeraprint{#2}}}}}%
+            \dateeraprint{#2endyear}}}}}%
   \endgroup}
 
 \endinput


### PR DESCRIPTION
The correct call is \dateera{<dateprefix>year} and not \dateera{<dateprefix>}.

See
https://tex.stackexchange.com/q/435750/35864
https://github.com/plk/biblatex/issues/679
https://github.com/plk/biblatex/commit/1440a0c7f6e99fc664df2a9ff6bafb346801b63d